### PR TITLE
Example script fetch_rss.php breaks if feed item links contain &

### DIFF
--- a/examples/fetch_rss.php
+++ b/examples/fetch_rss.php
@@ -35,7 +35,7 @@ foreach (qp($remote, 'channel>item') as $item) {
   $link = $item->next('link')->text();
   
   // Do a little string building.
-  $bullet = '<li><a href="' . $link . '">' . $title . '</a></li>';
+  $bullet = '<li><a href="' . htmlspecialchars($link, ENT_QUOTES, 'UTF-8') . '">' . $title . '</a></li>';
   
   // Add it to the output document.
   $out->append($bullet);


### PR DESCRIPTION
A QueryPathParseException is thrown in this case.

Stack trace:
#0 [internal function]: QueryPathParseException::initializeFromError(2, 'DOMDocumentFrag...', '/co...', 1973, Array)
#1 /code/querypath/src/QueryPath/QueryPath.php(1973): DOMDocumentFragment->appendXML('<li><a href="ht...')
#2 /code/querypath/src/QueryPath/QueryPath.php(1450): QueryPath->prepareInsert('<li><a href="ht...')
#3 /code/querypath/examples/fetch_rss.php(42): QueryPath->append('<li><a href="ht...')
#4 {main}

  thrown in /code/querypath/src/QueryPath/QueryPath.php on line 4430
