### PR TITLE
Update of adjacent() method

### DIFF
--- a/src/QueryPath/CssEventHandler.php
+++ b/src/QueryPath/CssEventHandler.php
@@ -1292,8 +1292,12 @@ class QueryPathCssEventHandler implements CssEventHandler {
     //$found = array();
     $found = new SplObjectStorage();
     foreach ($this->matches as $item) {
-      if (isset($item->nextSibling) && $item->nextSibling->nodeType === XML_ELEMENT_NODE) {
-        $found->attach($item->nextSibling);
+      while (isset($item->nextSibling)) {
+        if (isset($item->nextSibling) && $item->nextSibling->nodeType === XML_ELEMENT_NODE) {
+          $found->attach($item->nextSibling);
+          break;
+        }
+        $item = $item->nextSibling;
       }
     }
     $this->matches = $found;


### PR DESCRIPTION
See issue #65. I notice that there is a comment above the method touching on this very issue, so this pull request might be rejected. However, I believe that this should at least be the default behaviour of QueryPath if it is intending to replicate the function of CSS selectors and mimic jQuery - which it clearly is, as I understand it!
