### PR TITLE
Change to SPDX License Identifier (LGPL-2.1+ or MIT) for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "type": "library",
   "description": "HTML/XML querying and processing (like jQuery)",
   "homepage": "https://github.com/technosophos/querypath",
-  "license": "MIT-style",
+  "license": ["LGPL-2.1+", "MIT"],
   "keywords": ["xml", "html", "css", "jquery", "xslt"],
   "require" : {
     "php" : ">=5.2.0"


### PR DESCRIPTION
The `composer validate` command is now supporting [SPDX license identifers](http://spdx.org/licenses/).

As your package is used within other codebases (and has a composer.json file) I kindly ask you to change the license identifier in [`composer.json`](https://github.com/technosophos/querypath/blob/master/composer.json) from `MIT-like` to `(LGPL-2.1+ or MIT)` ([_GNU Lesser General Public License v2.1 or later_](http://spdx.org/licenses/LGPL-2.1+) or [_MIT License_](http://spdx.org/licenses/MIT)).

This suggestion has been done in good faith and is not a change of the license, just the way how it is identified. See as well [composer.json license property](http://getcomposer.org/doc/04-schema.md#license).

Please review the suggestion as it's an assumption only. The information given in your package was a bit ambigous for me whether it is GNU Lesser General Public License v2.1 _only_ or _or later_. `README.md` tells the first, whereas `COPYING-MIT.txt` tells the later.

---

License: Described in file [`README.md`](https://github.com/technosophos/querypath/blob/fa043002097b23a56e047b62fbec8796562545fb/README.md):

> This package is licensed under the GNU LGPL 2.1 (COPYING-LGPL.txt) or, at your choice, an MIT-style license (COPYING-MIT.txt). The licenses should have been distributed with this library.

File I: [`COPYING-LGPL.txt`](https://github.com/technosophos/querypath/blob/e51bacc31f964d3a0d25841a059be872da5a3173/COPYING-LGPL.txt) - LGPL-2.1+ license header:

> ... GNU Lesser General Public License ... ; either version 2.1 of the License, or (at your option) any later version. ...

File II: [`COPYING-MIT.txt`](https://github.com/technosophos/querypath/blob/f40fc3afa64bafd2d6776539bdbc297a8da6a54e/COPYING-MIT.txt) - MIT License  (assumed)

Assumed License: disjunctive: `LGPL-2.1+` ([_GNU Lesser General Public License v2.1 or later_](http://spdx.org/licenses/LGPL-2.1+)), `MIT` ([_MIT License_](http://spdx.org/licenses/MIT))
