### PR TITLE
Query interface is incorrect

### DIFF
--- a/src/QueryPath/Query.php
+++ b/src/QueryPath/Query.php
@@ -1,7 +1,7 @@
 <?php
 namespace QueryPath;
 interface Query {
-  public function __construct($documenti = NULL, $selector = NULL, $options = NULL);
+  public function __construct($document = NULL, $selector = NULL, $options = NULL);
   public function find($selector);
   public function top($selector = NULL);
   public function next($selector = NULL);


### PR DESCRIPTION
The Query interface in Query.php is incorrect. It defines required parameters for all functions, but most of these parameters are not required.
For example it's OK to call top() without a parameter:

``` php
function test(\QueryPath\Query $query) {
    $query->top();
}
```

Without my patch that leads into an error:
"Required parameter $selector missing. Invocation parameter types are not compatible with declared."
