### PR TITLE
Some safe API changes to run querypath2 and 3 in parallel

### DIFF
--- a/src/QueryPath/CSS/EventHandler.php
+++ b/src/QueryPath/CSS/EventHandler.php
@@ -19,12 +19,12 @@ namespace QueryPath\CSS;
  *
  *
  * Typically the parser is not accessed directly. Most developers will use it indirectly from
- * qp(), htmlqp(), or one of the methods on a QueryPath object.
+ * qp3(), htmlqp3(), or one of the methods on a QueryPath object.
  *
  * This parser is modular and is not tied to QueryPath, so you can use it in your
  * own (non-QueryPath) projects if you wish. To dive in, start with EventHandler, the
  * event interface that works like a SAX API for CSS selectors. If you want to check out
- * the details, check out the parser (QueryPath::CSS::Parser),  scanner 
+ * the details, check out the parser (QueryPath::CSS::Parser),  scanner
  * (QueryPath::CSS::Scanner), and token list (QueryPath::CSS::Token).
  */
 

--- a/src/QueryPath/DOMQuery.php
+++ b/src/QueryPath/DOMQuery.php
@@ -7,20 +7,19 @@
  * was done for a few reasons:
  * - The library has been refactored, and it made more sense to call the top
  *   level class QueryPath. This is not the top level class.
- * - There have been requests for a JSONQuery class, which would be the 
+ * - There have been requests for a JSONQuery class, which would be the
  *   natural complement of DOMQuery.
  */
 
 namespace QueryPath;
 
 use \QueryPath\CSS\QueryPathEventHandler;
-use \QueryPath;
 
 
 /**
  * The DOMQuery object is the primary tool in this library.
  *
- * To create a new DOMQuery, use QueryPath::with() or qp() function.
+ * To create a new DOMQuery, use QueryPath::with() or qp3() function.
  *
  * If you are new to these documents, start at the QueryPath.php page.
  * There you will find a quick guide to the tools contained in this project.
@@ -30,7 +29,7 @@ use \QueryPath;
  * extensions, and there is no guarantee that extensions can serialize. The
  * moral of the story: Don't serialize DOMQuery.
  *
- * @see qp()
+ * @see qp3()
  * @see QueryPath.php
  * @ingroup querypath_core
  */
@@ -85,7 +84,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    * Constructor.
    *
    * Typically, a new DOMQuery is created by QueryPath::with(), QueryPath::withHTML(),
-   * qp(), or htmlqp().
+   * qp3(), or htmlqp3().
    *
    * @param mixed $document
    *   A document-like object.
@@ -93,7 +92,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    *   A CSS 3 Selector
    * @param array $options
    *   An associative array of options.
-   * @see qp()
+   * @see qp3()
    */
   public function __construct($document = NULL, $string = NULL, $options = array()) {
     $string = trim($string);
@@ -203,14 +202,14 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    *
    * This returns an associative array of all of the options as set
    * for the current DOMQuery object. This includes default options,
-   * options directly passed in via {@link qp()} or the constructor,
+   * options directly passed in via {@link qp3()} or the constructor,
    * an options set in the QueryPath::Options object.
    *
    * The order of merging options is this:
-   *  - Options passed in using qp() are highest priority, and will
+   *  - Options passed in using qp3() are highest priority, and will
    *    override other options.
    *  - Options set with QueryPath::Options will override default options,
-   *    but can be overridden by options passed into qp().
+   *    but can be overridden by options passed into qp3().
    *  - Default options will be used when no overrides are present.
    *
    * This function will return the options currently used, with the above option
@@ -219,7 +218,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    * @return array
    *  An associative array of options, calculated from defaults and overridden
    *  options.
-   * @see qp()
+   * @see qp3()
    * @see QueryPath::Options::set()
    * @see QueryPath::Options::merge()
    * @since 2.0
@@ -234,7 +233,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    * This sets the current match to the document's root element. For
    * practical purposes, this is the same as:
    * @code
-   * qp($someDoc)->find(':root');
+   * qp3($someDoc)->find(':root');
    * @endcode
    * However, since it doesn't invoke a parser, it has less overhead. It also
    * works in cases where the QueryPath has been reduced to zero elements (a
@@ -352,7 +351,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    *
    * @code
    * <?php
-   *  count(qp($xml, 'div'));
+   *  count(qp3($xml, 'div'));
    * ?>
    * @endcode
    *
@@ -377,8 +376,8 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    * Calling this method does not change the DOMQuery (e.g. it is
    * non-destructive).
    *
-   * You can use qp()->get() to iterate over all elements matched. You can
-   * also iterate over qp() itself (DOMQuery implementations must be Traversable).
+   * You can use qp3()->get() to iterate over all elements matched. You can
+   * also iterate over qp3() itself (DOMQuery implementations must be Traversable).
    * In the later case, though, each item
    * will be wrapped in a DOMQuery object. To learn more about iterating
    * in QueryPath, see {@link examples/techniques.php}.
@@ -535,7 +534,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    * For example, consider this code:
    * @code
    * <?php
-   * qp(HTML_STUB, 'body')->css('background-color','red')->html();
+   * qp3(HTML_STUB, 'body')->css('background-color','red')->html();
    * ?>
    * @endcode
    * This will return the following HTML:
@@ -547,7 +546,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    * element will be returned unparsed. Example:
    * @code
    * <?php
-   * qp(HTML_STUB, 'body')->css('background-color','red')->css();
+   * qp3(HTML_STUB, 'body')->css('background-color','red')->css();
    * ?>
    * @endcode
    * This will return the following:
@@ -669,7 +668,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
       }
     }
     else {
-      $attVal = \QueryPath::encodeDataURL($data, $mime, $context);
+      $attVal = \QueryPath\QueryPath::encodeDataURL($data, $mime, $context);
       return $this->attr($attr, $attVal);
     }
   }
@@ -835,8 +834,8 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    * @code
    * <?php
    * $comp = function (\DOMNode $a, \DOMNode $b) {
-   *   $qpa = qp($a);
-   *   $qpb = qp($b);
+   *   $qpa = qp3($a);
+   *   $qpb = qp3($b);
    *
    *   if ($qpa->text() == $qpb->text()) {
    *     return 0;
@@ -904,7 +903,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    *
    * Example:
    * @code
-   * qp('li')->filterLambda('qp($item)->attr("id") == "test"');
+   * qp3('li')->filterLambda('qp3($item)->attr("id") == "test"');
    * @endcode
    *
    * The above would filter down the list to only an item whose ID is
@@ -946,11 +945,11 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    * @code
    *  <?php
    *    // This will be 1.
-   *    qp($xml, 'div')->filterPreg('/World/')->size();
+   *    qp3($xml, 'div')->filterPreg('/World/')->size();
    *  ?>
    * @endcode
    *
-   * The return value above will be 1 because the text content of @codeqp($xml, 'div')@endcode is
+   * The return value above will be 1 because the text content of @codeqp3($xml, 'div')@endcode is
    * @codeHello World@endcode.
    *
    * Compare this to the behavior of the <em>:contains()</em> CSS3 pseudo-class.
@@ -1356,7 +1355,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    *
    * @param mixed $data
    *  The data to be inserted. This can be XML in a string, a DomFragment, a DOMElement,
-   *  or the other usual suspects. (See {@link qp()}).
+   *  or the other usual suspects. (See {@link qp3()}).
    * @retval object DOMQuery
    *  Returns the DOMQuery with the new modifications. The list of elements currently
    *  selected will remain the same.
@@ -1481,7 +1480,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    *
    * Now we can run this code:
    * @code
-   *   qp($xml, 'content')->unwrap();
+   *   qp3($xml, 'content')->unwrap();
    * @endcode
    *
    * This will result in:
@@ -1887,7 +1886,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
       $node = $document->importNode($node);
       $item->parentNode->replaceChild($node, $item);
     }
-    return QueryPath::with($document, NULL, $this->options);
+    return \QueryPath\QueryPath::with($document, NULL, $this->options);
   }
   /**
    * Add more elements to the current set of matches.
@@ -1910,7 +1909,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
     // This is destructive, so we need to set $last:
     $this->last = $this->matches;
 
-    foreach (QueryPath::with($this->document, $selector, $this->options)->get() as $item) {
+    foreach (\QueryPath\QueryPath::with($this->document, $selector, $this->options)->get() as $item) {
       $this->matches->attach($item);
     }
     return $this;
@@ -1934,12 +1933,12 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    * an empty set of matches. Example:
    *
    * @code
-   * // The line below returns the same thing as qp(document, 'p');
-   * qp(document, 'p')->find('div')->end();
+   * // The line below returns the same thing as qp3(document, 'p');
+   * qp3(document, 'p')->find('div')->end();
    * // This returns an empty array:
-   * qp(document, 'p')->end();
+   * qp3(document, 'p')->end();
    * // This returns an empty array:
-   * qp(document, 'p')->find('div')->find('span')->end()->end();
+   * qp3(document, 'p')->find('div')->find('span')->end()->end();
    * @endcode
    *
    * The last one returns an empty array because only one level of changes is stored.
@@ -1964,7 +1963,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    * Example:
    *
    * @code
-   * qp(document, 'p')->find('div')->andSelf();
+   * qp3(document, 'p')->find('div')->andSelf();
    * @endcode
    *
    * The code above will contain a list of all p elements and all div elements that
@@ -2137,14 +2136,14 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
     $found = new \SplObjectStorage();
     foreach ($this->matches as $m) {
 
-      if (QueryPath::with($m, NULL, $this->options)->is($selector) > 0) {
+      if (\QueryPath\QueryPath::with($m, NULL, $this->options)->is($selector) > 0) {
         $found->attach($m);
       }
       else {
         while ($m->parentNode->nodeType !== XML_DOCUMENT_NODE) {
           $m = $m->parentNode;
           // Is there any case where parent node is not an element?
-          if ($m->nodeType === XML_ELEMENT_NODE && QueryPath::with($m, NULL, $this->options)->is($selector) > 0) {
+          if ($m->nodeType === XML_ELEMENT_NODE && \QueryPath\QueryPath::with($m, NULL, $this->options)->is($selector) > 0) {
             $found->attach($m);
             break;
           }
@@ -2179,7 +2178,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
         // Is there any case where parent node is not an element?
         if ($m->nodeType === XML_ELEMENT_NODE) {
           if (!empty($selector)) {
-            if (QueryPath::with($m, NULL, $this->options)->is($selector) > 0) {
+            if (\QueryPath\QueryPath::with($m, NULL, $this->options)->is($selector) > 0) {
               $found->attach($m);
               break;
             }
@@ -2214,7 +2213,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
         // Is there any case where parent node is not an element?
         if ($m->nodeType === XML_ELEMENT_NODE) {
           if (!empty($selector)) {
-            if (QueryPath::with($m, NULL, $this->options)->is($selector) > 0)
+            if (\QueryPath\QueryPath::with($m, NULL, $this->options)->is($selector) > 0)
               $found->attach($m);
           }
           else
@@ -2305,7 +2304,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    * We can retrieve just the contents of this code by doing something like
    * this:
    * @code
-   * qp($xml, 'div')->innerHTML();
+   * qp3($xml, 'div')->innerHTML();
    * @endcode
    *
    * This would return the following:
@@ -2482,10 +2481,10 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    * $xml = '<?xml version="1.0"?><root>Foo<a>Bar</a><b/></root>';
    *
    * // This will return 'Foo'
-   * qp($xml, 'a')->textBefore();
+   * qp3($xml, 'a')->textBefore();
    *
    * // This will insert 'Baz' right before <b/>.
-   * qp($xml, 'b')->textBefore('Baz');
+   * qp3($xml, 'b')->textBefore('Baz');
    * ?>
    * @endcode
    *
@@ -2815,7 +2814,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
         $m = $m->nextSibling;
         if ($m->nodeType === XML_ELEMENT_NODE) {
           if (!empty($selector)) {
-            if (QueryPath::with($m, NULL, $this->options)->is($selector) > 0) {
+            if (\QueryPath\QueryPath::with($m, NULL, $this->options)->is($selector) > 0) {
               $found->attach($m);
               break;
             }
@@ -2852,7 +2851,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
         $m = $m->nextSibling;
         if ($m->nodeType === XML_ELEMENT_NODE) {
           if (!empty($selector)) {
-            if (QueryPath::with($m, NULL, $this->options)->is($selector) > 0) {
+            if (\QueryPath\QueryPath::with($m, NULL, $this->options)->is($selector) > 0) {
               $found->attach($m);
             }
           }
@@ -2888,7 +2887,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
         $m = $m->previousSibling;
         if ($m->nodeType === XML_ELEMENT_NODE) {
           if (!empty($selector)) {
-            if (QueryPath::with($m, NULL, $this->options)->is($selector)) {
+            if (\QueryPath\QueryPath::with($m, NULL, $this->options)->is($selector)) {
               $found->attach($m);
               break;
             }
@@ -2925,7 +2924,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
         $m = $m->previousSibling;
         if ($m->nodeType === XML_ELEMENT_NODE) {
           if (!empty($selector)) {
-            if (QueryPath::with($m, NULL, $this->options)->is($selector)) {
+            if (\QueryPath\QueryPath::with($m, NULL, $this->options)->is($selector)) {
               $found->attach($m);
             }
           }
@@ -2980,7 +2979,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    *
    * Executing this fragment of code will remove only the 'first' class:
    * @code
-   * qp(document, 'element')->removeClass('first');
+   * qp3(document, 'element')->removeClass('first');
    * @endcode
    *
    * The resulting XML will be:
@@ -3069,10 +3068,10 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    *
    * @code
    * <?php
-   * $qp = qp( QueryPath::HTML_STUB);
-   * $branch = $qp->branch();
+   * $qp = qp3( QueryPath::HTML_STUB);
+   * $branch = $qp3->branch();
    * $branch->find('title')->text('Title');
-   * $qp->find('body')->text('This is the body')->writeHTML;
+   * $qp3->find('body')->text('This is the body')->writeHTML;
    * ?>
    * @endcode
    *
@@ -3111,7 +3110,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    * @see find()
    */
   public function branch($selector = NULL) {
-    $temp = \QueryPath::with($this->matches, NULL, $this->options);
+    $temp = \QueryPath\QueryPath::with($this->matches, NULL, $this->options);
     //if (isset($selector)) $temp->find($selector);
     $temp->document = $this->document;
     if (isset($selector)) $temp->findInPlace($selector);
@@ -3119,7 +3118,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
   }
   protected function inst($matches, $selector, $options) {
     /*
-    $temp = \QueryPath::with($matches, NULL, $options);
+    $temp = \QueryPath\QueryPath::with($matches, NULL, $options);
     //if (isset($selector)) $temp->find($selector);
     $temp->document = $this->document;
     if (isset($selector)) $temp->findInPlace($selector);
@@ -3146,7 +3145,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    *
    * This is a destructive operation, which means that end() will revert
    * the list back to the clone's original.
-   * @see qp()
+   * @see qp3()
    * @retval object DOMQuery
    */
   public function cloneAll() {
@@ -3479,7 +3478,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
         $m = $m->nextSibling;
         if ($m->nodeType === XML_ELEMENT_NODE) {
           if (!empty($selector)) {
-            if (QueryPath::with($m, NULL, $this->options)->is($selector) > 0) {
+            if (\QueryPath\QueryPath::with($m, NULL, $this->options)->is($selector) > 0) {
               break;
             }
             else {
@@ -3520,7 +3519,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
       while (isset($m->previousSibling)) {
         $m = $m->previousSibling;
         if ($m->nodeType === XML_ELEMENT_NODE) {
-          if (!empty($selector) && QueryPath::with($m, NULL, $this->options)->is($selector))
+          if (!empty($selector) && \QueryPath\QueryPath::with($m, NULL, $this->options)->is($selector))
           break;
           else
           $found->attach($m);
@@ -3553,7 +3552,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
         // Is there any case where parent node is not an element?
         if ($m->nodeType === XML_ELEMENT_NODE) {
           if (!empty($selector)) {
-            if (QueryPath::with($m, NULL, $this->options)->is($selector) > 0)
+            if (\QueryPath\QueryPath::with($m, NULL, $this->options)->is($selector) > 0)
             break;
             else
             $found->attach($m);
@@ -3683,7 +3682,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
       $this->matches = $found;
     }
 
-    // EXPERIMENTAL: Support for qp()->length.
+    // EXPERIMENTAL: Support for qp3()->length.
     $this->length = $this->matches->count();
   }
 
@@ -3829,7 +3828,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
     // enough extensions.)
     //
     // The main reason for moving this out of the constructor is that most
-    // new DOMQuery instances do not use extensions. Charging qp() calls
+    // new DOMQuery instances do not use extensions. Charging qp3() calls
     // with the additional hit is not a good idea.
     //
     // Also, this will at least limit the number of circular references.

--- a/src/QueryPath/Extension.php
+++ b/src/QueryPath/Extension.php
@@ -75,13 +75,13 @@ namespace QueryPath;
  * QueryPath extensions are called like regular QueryPath functions. For
  * example, the extension above can be called like this:
  * <code>
- * qp('some.xml')->stubToe();
+ * qp3('some.xml')->stubToe();
  * // or
  * QueryPath::with('some.xml')->stubToe();
  * </code>
  * Since it returns the Query ($qp) object, chaining is supported:
  * <code>
- * print qp('some.xml')->stubToe()->xml();
+ * print qp3('some.xml')->stubToe()->xml();
  * </code>
  * When you write your own extensions, anything that does not need to return a
  * specific value should return the Query object. Between that and the

--- a/src/QueryPath/Extension/QPXML.php
+++ b/src/QueryPath/Extension/QPXML.php
@@ -187,7 +187,7 @@ class QPXML implements \QueryPath\Extension {
       } else {
         $node = $element->ownerDocument->createElement($text);
       }
-        return QueryPath::with($node);
+        return \QueryPath\QueryPath::with($node);
       }
     }
     return;
@@ -203,7 +203,7 @@ class QPXML implements \QueryPath\Extension {
     if (isset ($text)) {
       foreach ($this->qp->get() as $element) {
         $node = $this->qp->createElement($text);
-        QueryPath::with($element)->append($node);
+        \QueryPath\QueryPath::with($element)->append($node);
       }
     }
     return $this->qp;

--- a/src/QueryPath/Extension/QPXSL.php
+++ b/src/QueryPath/Extension/QPXSL.php
@@ -30,7 +30,7 @@ namespace QueryPath\Extension;
  * require 'QueryPath/QueryPath.php';
  * require 'QueryPath/Extension/QPXSL.php';
  *
- * qp('src.xml')->xslt('stylesheet.xml')->writeXML();
+ * qp3('src.xml')->xslt('stylesheet.xml')->writeXML();
  * ?>
  *
  * This will transform src.xml according to the XSLT rules in
@@ -56,7 +56,7 @@ class QPXSL implements \QueryPath\Extension {
    *
    * @param mixed $style
    *  This takes a QueryPath object or <em>any</em> of the types that the
-   *  {@link qp()} function can take.
+   *  {@link qp3()} function can take.
    * @return QueryPath
    *  A QueryPath object wrapping the transformed document. Note that this is a
    *  <i>different</em> document than the original. As such, it has no history.
@@ -64,13 +64,13 @@ class QPXSL implements \QueryPath\Extension {
    *  the original source document will remain unchanged.)
    */
   public function xslt($style) {
-    if (!($style instanceof QueryPath)) {
-      $style = \QueryPath::with($style);
+    if (!($style instanceof \QueryPath\QueryPath)) {
+      $style = \QueryPath\QueryPath::with($style);
     }
     $sourceDoc = $this->src->top()->get(0)->ownerDocument;
     $styleDoc = $style->get(0)->ownerDocument;
     $processor = new \XSLTProcessor();
     $processor->importStylesheet($styleDoc);
-    return \QueryPath::with($processor->transformToDoc($sourceDoc));
+    return \QueryPath\QueryPath::with($processor->transformToDoc($sourceDoc));
   }
 }

--- a/src/QueryPath/ExtensionRegistry.php
+++ b/src/QueryPath/ExtensionRegistry.php
@@ -122,7 +122,7 @@ class ExtensionRegistry {
    *
    * If extension autoloading is disabled, then QueryPath will not
    * automatically load all registred extensions when a new Query
-   * object is created using qp().
+   * object is created using qp3().
    */
   public static function autoloadExtensions($boolean = TRUE) {
     self::$useRegistry = $boolean;

--- a/src/QueryPath/Options.php
+++ b/src/QueryPath/Options.php
@@ -20,11 +20,11 @@ namespace QueryPath;
  * When a QueryPath object is created, it will evaluate options in the
  * following order:
  *
- * - Options passed into qp() have highest priority.
+ * - Options passed into qp3() have highest priority.
  * - Options in QueryPath::Options (this class) have the next highest priority.
  * - If the option is not specified elsewhere, QueryPath will use its own defaults.
  *
- * @see qp()
+ * @see qp3()
  * @see QueryPath::Options::set()
  * @ingroup querypath_util
  */

--- a/src/QueryPath/QueryPath.php
+++ b/src/QueryPath/QueryPath.php
@@ -7,7 +7,7 @@
  * build, parse, search, and modify DOM documents.
  *
  * To use QueryPath, only one file must be imported: qp.php. This file defines
- * the `qp()` function, and also registers an autoloader if necessary.
+ * the `qp3()` function, and also registers an autoloader if necessary.
  *
  * Standard usage:
  * @code
@@ -17,7 +17,7 @@
  * $xml = '<?xml version="1.0"?><test><foo id="myID"/></test>';
  *
  * // Procedural call a la jQuery:
- * $qp = qp($xml, '#myID');
+ * $qp = qp3($xml, '#myID');
  * $qp->append('<new><elements/></new>')->writeHTML();
  *
  * // Object-oriented version with a factory:
@@ -43,7 +43,7 @@
  * To gain familiarity with QueryPath, the following three API docs are
  * the best to start with:
  *
- *- qp(): This function constructs new queries, and is the starting point
+ *- qp3(): This function constructs new queries, and is the starting point
  *  for manipulating a document. htmlqp() is an alias tuned for HTML
  *  documents (especially old HTML), and QueryPath::with(), QueryPath::withXML()
  *  and QueryPath::withHTML() all perform a similar role, but in a purely
@@ -75,7 +75,7 @@
  * @author M Butcher <matt @aleph-null.tv>
  * @license MIT
  * @see QueryPath
- * @see qp()
+ * @see qp3()
  * @see http://querypath.org The QueryPath home page.
  * @see http://api.querypath.org An online version of the API docs.
  * @see http://technosophos.com For how-tos and examples.
@@ -83,6 +83,8 @@
  * @version -UNSTABLE% (3.x.x)
  *
  */
+
+namespace QueryPath;
 
 /**
  *
@@ -142,11 +144,11 @@ class QueryPath {
    * fragment. For example, you should use {@link xml()}, {@link innerXML()}, and
    * {@link writeXML()}.
    *
-   * This can be passed into {@link qp()} to begin a new basic HTML document.
+   * This can be passed into {@link qp3()} to begin a new basic HTML document.
    *
    * Example:
    * @code
-   * $qp = qp(QueryPath::XHTML_STUB); // Creates a new XHTML document
+   * $qp = qp3(QueryPath::XHTML_STUB); // Creates a new XHTML document
    * $qp->writeXML(); // Writes the document as well-formed XHTML.
    * @endcode
    * @since 2.0
@@ -196,7 +198,7 @@ class QueryPath {
   /**
    * Enable one or more extensions.
    *
-   * Extensions provide additional features to QueryPath. To enable and 
+   * Extensions provide additional features to QueryPath. To enable and
    * extension, you can use this method.
    *
    * In this example, we enable the QPTPL extension:

--- a/src/QueryPath/QueryPathIterator.php
+++ b/src/QueryPath/QueryPathIterator.php
@@ -21,7 +21,7 @@ class QueryPathIterator extends \IteratorIterator {
 
   public function current() {
     if (!isset($this->qp)) {
-      $this->qp = \QueryPath::with(parent::current(), NULL, $this->options);
+      $this->qp = \QueryPath\QueryPath::with(parent::current(), NULL, $this->options);
     }
     else {
       $splos = new \SplObjectStorage();

--- a/src/documentation.php
+++ b/src/documentation.php
@@ -6,21 +6,21 @@
  *
  * @section getting_started Getting Started
  *
- * To being using QueryPath, you will probably want to take a look at these three pieces of 
+ * To being using QueryPath, you will probably want to take a look at these three pieces of
  * documentation:
- *  - qp(): The main QueryPath function (like jQuery's $ function.)
- *  - htmlqp(): A specialized version of qp() for dealing with poorly formatted HTML.
+ *  - qp3(): The main QueryPath function (like jQuery's $ function.)
+ *  - htmlqp3(): A specialized version of qp3() for dealing with poorly formatted HTML.
  *  - QueryPath: The QueryPath class, which has all of the main functions.
  *
- * One substantial difference from jQuery is that QueryPath does not return a new object for 
+ * One substantial difference from jQuery is that QueryPath does not return a new object for
  * each call (for performance reasons). Instead, the same object is mutated from call to call.
  * A chain, then, typically performs all methods on the same object.
- * When you need multiple objects, QueryPath has a {@link QueryPath::branch()} function that 
+ * When you need multiple objects, QueryPath has a {@link QueryPath::branch()} function that
  * will return a cloned QueryPath object.
  *
- * QueryPath also has numerous functions that jQuery does not. Some (like QueryPath::top() and 
+ * QueryPath also has numerous functions that jQuery does not. Some (like QueryPath::top() and
  * QueryPath::dataURL()) are extensions we find useful.
- * Most, however, are to either emphasize PHP features (QueryPath::filterPreg()) or adapt to 
+ * Most, however, are to either emphasize PHP features (QueryPath::filterPreg()) or adapt to
  * server-side needs (QueryPathEntities::replaceAllEntities()).
  *
  * @subsection basic_example A Few Basic Examples
@@ -29,57 +29,57 @@
  *
  * @code
  * require 'QueryPath/QueryPath.php';
- * 
- * qp('<?xml version="1.0"?><root><foo/></root>', 'foo')->append('<bar>baz</bar>')->writeXML();
+ *
+ * qp3('<?xml version="1.0"?><root><foo/></root>', 'foo')->append('<bar>baz</bar>')->writeXML();
  * @endcode
  *
- * The above will create a new document from the XML string, find the <code>foo</code> element, and then 
+ * The above will create a new document from the XML string, find the <code>foo</code> element, and then
  * append the <code>bar</code> element (complete with its text). Finally, the call to QueryPath::writeXML() will
  * print the entire finished XML document to standard out (usually the web browser).
  *
- * Here's an example using htmlqp():
+ * Here's an example using htmlqp3():
  *
  * @code
  * require 'QueryPath/QueryPath.php';
- * 
+ *
  * // URL to fetch:
  * $url = 'http://technosophos.com';
  *
- * print htmlqp($url, 'title')->text();
+ * print htmlqp3($url, 'title')->text();
  * @endcode
  *
  * The above will fetch the HTML from the given URL and then find the <code>title</code> tag. It will extract
  * the text (QueryPath::text()) from the title and print it.
  *
- * For more examples, check out the #Examples namespace (start with {@link examples/html.php}). Also, read about the 
- * qp() and htmlqp() functions.
+ * For more examples, check out the #Examples namespace (start with {@link examples/html.php}). Also, read about the
+ * qp3() and htmlqp3() functions.
  *
  * @subsection online_sources Online Sources
  *
  *   - The official QueryPath site http://querypath.org
  *   - The latest API docs http://api.querypath.org
- *   - IBM DeveloperWorks Intro to QueryPath http://www.ibm.com/developerworks/web/library/os-php-querypath/index.html 
+ *   - IBM DeveloperWorks Intro to QueryPath http://www.ibm.com/developerworks/web/library/os-php-querypath/index.html
  *   - QueryPath articles at TechnoSophos.Com http://technosophos.com/qp/articles
  *   - The QueryPath GitHub repository http://github.com/technosophos/querypath
  *
- * If you find a good online resource, please submit it as an issue in GitHub, and we will 
+ * If you find a good online resource, please submit it as an issue in GitHub, and we will
  * most likely add it here.
  *
  * @subsection more_examples A Larger Example
  *
  * @include examples/html.php
- * 
+ *
  * @page extensions Using and Writing Extensions
  *
  * Using an extension is as easy as including it in your code:
- * 
+ *
  * @code
  * <?php
  * require 'QueryPath/QueryPath.php';
  * require 'QueryPath/Extension/QPXML.php';
  *
  * // Now I have the QPXML methods available:
- * qp(QueryPath::HTML_STUB)->comment('This is an HTML comment.');
+ * qp3(\QueryPath\QueryPath::HTML_STUB)->comment('This is an HTML comment.');
  * ?>
  * @endcode
  *
@@ -91,45 +91,45 @@
  * QueryPathExtension is the master interface for all extensions.
  *
  */
- 
+
 
 /** @page CSSReference CSS Selector Reference
- * QueryPath provides two query 'languages' that you can use to search through XML and HTML 
+ * QueryPath provides two query 'languages' that you can use to search through XML and HTML
  * documents. The main query language is an implementation of the CSS3 Selectors specification. This
  * is the query language that jQuery and CSS use -- and more recently, FireFox itself supports it
  * via its JavaScript API. CSS3 should be familiar to developers and designers who have worked with
  * HTML and stylesheets.
  *
- * QueryPath also allows XPath selectors, which can be executed using QueryPath::xpath(). While 
+ * QueryPath also allows XPath selectors, which can be executed using QueryPath::xpath(). While
  * fewer functions take XPath expressions, it is noless a powerful tool for querying DOM objects.
  *
  * @code
  * <?php
- * qp($xml)->xpath('//foo');
+ * qp3($xml)->xpath('//foo');
  * ?>
  * @endcode
- * 
+ *
  * QueryPath provides a full CSS3 selector implementation, including all of the specified operators,
  * robost not() and has() support, pseudo-class/elements, and XML namespace support.
  *
- * Selectors can be passed into a number of QueryPath functions including qp(), htmlqp(), 
+ * Selectors can be passed into a number of QueryPath functions including qp3(), htmlqp3(),
  * QueryPath::find(), QueryPath::top(), QueryPath::children() and others.
  * @code
  * <?php
- * $qp = qp($html, 'body'); // Find the body
+ * $qp = qp3($html, 'body'); // Find the body
  * $another_qp = $qp->branch('p'); // Create another QP object that searches BODY for P tags.
  * $qp->find('strong>a'); // Find all of the A elements directly inside of STRONG elements.
  * $qp->top('head'); // Start over at the top of the document, and find the HEAD tag.
  * ?>
  * @endcode
  *
- * In all of the examples above, CSS selectors are used to locate specific things inside of the 
+ * In all of the examples above, CSS selectors are used to locate specific things inside of the
  * document.
  *
  * @section selector_examples Example Selectors
  * Example selectors:
  * - <code>p</code>: Select all P elements in a document.
- * - <code>strong a</code>: Select any A elements that are inside (children or descendants of) a STRONG 
+ * - <code>strong a</code>: Select any A elements that are inside (children or descendants of) a STRONG
  *    element.
  * - <code>strong>a</code>: Select only A elements that are directly beneath STRONG elements.
  * - <code>:root>head</code> select HEAD elements that are directly beneath the document root.
@@ -141,15 +141,15 @@
  * - <code>p:not(.nav)</code>: Select any elements in P that do not have the nav class.
  *
  * @section pseudo_reference Pseudo-class and pseudo-element selectors
- * QueryPath provides an implementation of the CSS3 spec, including the CSS3 pseudo-classes and 
+ * QueryPath provides an implementation of the CSS3 spec, including the CSS3 pseudo-classes and
  * pseudo-elements defined in the spec. Some of the CSS3 pseudo-classes require a user agent, and
  * so cannot be adequately captured on the server side, but all others have been implemented.
  *
  * Additionally, jQuery has added its own pseudo-classes, and jQuery users have come to expect those
- * to work. So for the sake of convenience, we have implemented those as well. These include the 
+ * to work. So for the sake of convenience, we have implemented those as well. These include the
  * form pseudo-classes, along with several others.
  *
- * Finally, QueryPath has added a couple of useful pseudo-classes, namely :x-root and 
+ * Finally, QueryPath has added a couple of useful pseudo-classes, namely :x-root and
  * :contains-exactly.
  *
  * @subsection pseudoelement_ref Pseudo-Elements
@@ -170,7 +170,7 @@
  *
  * @code
  * <?php
- * $textNode = qp($xml, 'p::first-letter')->get();
+ * $textNode = qp3($xml, 'p::first-letter')->get();
  * ?>
  * @endcode
  *
@@ -221,7 +221,7 @@
  * - has: Matches any items that have children that match the given selector, e.g. <code>:has(strong>a)</code>
  * - contains: Contains *text* that matches. This is a substring match.
  * - contains-exactly: Contains *exactly* the given text. This is NOT a substring match.
- * 
+ *
  * These generate errors because they are not implemented:
  * - indeterminate
  * - lang
@@ -239,23 +239,23 @@
  * Examples:
  * @code
  * <?php
- * qp($html, 'form input:text'); // Get all text input elements in a form.
+ * qp3($html, 'form input:text'); // Get all text input elements in a form.
  * ?>
  * @endcode
  * @section xml_namespaces XML Namespaces
  * QueryPath also supports the CSS3 namespace selection syntax. <b>This is syntactically different
- * than the XML namespace tag format</b>. To select a tag whose namespaced name is foo:bar, the 
- * CSS element selector would be <code>foo|bar</code> (note the vertical bar instead of a colon). While 
- * QueryPath does its best to resolve namespaces to short names, there is a possibility that a 
+ * than the XML namespace tag format</b>. To select a tag whose namespaced name is foo:bar, the
+ * CSS element selector would be <code>foo|bar</code> (note the vertical bar instead of a colon). While
+ * QueryPath does its best to resolve namespaces to short names, there is a possibility that a
  * malformed namespace will prevent specific namespace queries.
  *
  * You can also query across namespaces with <code>*|tagname</code>.
  *
  * @code
  * <?php
- * qp($xml, 'atom|entry'); // Find all <atom:entry> elements.
- * qp($xml, 'atom|entry > xmedia|video'); // Find all <xmedia:video> elements directly inside <atom:entry> elements.
- * qp($xml, '*|entry'); // Find any namespaced tag that has `entry` as the tag name.
+ * qp3($xml, 'atom|entry'); // Find all <atom:entry> elements.
+ * qp3($xml, 'atom|entry > xmedia|video'); // Find all <xmedia:video> elements directly inside <atom:entry> elements.
+ * qp3($xml, '*|entry'); // Find any namespaced tag that has `entry` as the tag name.
  * ?>
  * @endcode
  */

--- a/src/qp.php
+++ b/src/qp.php
@@ -12,13 +12,13 @@
  * <?php
  * require 'qp.php';
  *
- * qp($xml)->find('foo')->count();
+ * qp3($xml)->find('foo')->count();
  * ?>
  * @endcode
  *
  * If no autoloader is currently operating, this will use
- * QueryPath's default autoloader **unless** 
- * QP_NO_AUTOLOADER is defined, in which case all of the 
+ * QueryPath's default autoloader **unless**
+ * QP_NO_AUTOLOADER is defined, in which case all of the
  * files will be statically required in.
  */
 
@@ -55,7 +55,7 @@ if (!class_exists('\QueryPath\QueryPath')) {
     require __DIR__ . '/QueryPath/Options.php';
     require __DIR__ . '/QueryPath/QueryPathIterator.php';
     require __DIR__ . '/QueryPath/DOMQuery.php';
-    require __DIR__ . '/QueryPath.php';
+    require __DIR__ . '/QueryPath/QueryPath.php';
   }
   else {
     spl_autoload_register(function ($klass) {
@@ -70,7 +70,7 @@ if (!class_exists('\QueryPath\QueryPath')) {
   }
 }
 
-// Define qp() and qphtml() function.
-if (!function_exists('qp')) {
+// Define qp3() and qphtml3() function.
+if (!function_exists('qp3')) {
     require __DIR__ . '/qp_functions.php';
 }

--- a/src/qp_functions.php
+++ b/src/qp_functions.php
@@ -12,7 +12,7 @@
  * <?php
  * require 'qp.php';
  *
- * qp($xml)->find('foo')->count();
+ * qp3($xml)->find('foo')->count();
  * ?>
  * @endcode
  */
@@ -21,7 +21,7 @@
  * Core classes and functions for QueryPath.
  *
  * These are the classes, objects, and functions that developers who use QueryPath
- * are likely to use. The qp() and htmlqp() functions are the best place to start,
+ * are likely to use. The qp3() and htmlqp3() functions are the best place to start,
  * while most of the frequently used methods are part of the QueryPath object.
  */
 
@@ -56,14 +56,14 @@
  * Example:
  * @code
  * <?php
- * qp(); // New empty QueryPath
- * qp('path/to/file.xml'); // From a file
- * qp('<html><head></head><body></body></html>'); // From HTML or XML
- * qp(QueryPath::XHTML_STUB); // From a basic HTML document.
- * qp(QueryPath::XHTML_STUB, 'title'); // Create one from a basic HTML doc and position it at the title element.
+ * qp3(); // New empty QueryPath
+ * qp3('path/to/file.xml'); // From a file
+ * qp3('<html><head></head><body></body></html>'); // From HTML or XML
+ * qp3(\QueryPath\QueryPath::XHTML_STUB); // From a basic HTML document.
+ * qp3(\QueryPath\QueryPath::XHTML_STUB, 'title'); // Create one from a basic HTML doc and position it at the title element.
  *
  * // Most of the time, methods are chained directly off of this call.
- * qp(QueryPath::XHTML_STUB, 'body')->append('<h1>Title</h1>')->addClass('body-class');
+ * qp3(\QueryPath\QueryPath::XHTML_STUB, 'body')->append('<h1>Title</h1>')->addClass('body-class');
  * ?>
  * @endcode
  *
@@ -73,7 +73,7 @@
  *
  * <b>Types of documents that QueryPath can support</b>
  *
- *  qp() can take any of these as its first argument:
+ *  qp3() can take any of these as its first argument:
  *
  *  - A string of XML or HTML (See {@link XHTML_STUB})
  *  - A path on the file system or a URL
@@ -135,7 +135,7 @@
  *    If you want to change this, you can set this option with one of the
  *    JS_CSS_ESCAPE_* constants, or you can write your own.
  *  - QueryPath_class: (ADVANCED) Use this to set the actual classname that
- *    {@link qp()} loads as a QueryPath instance. It is assumed that the
+ *    {@link qp3()} loads as a QueryPath instance. It is assumed that the
  *    class is either {@link QueryPath} or a subclass thereof. See the test
  *    cases for an example.
  *
@@ -148,14 +148,14 @@
  *  An associative array of options. Currently supported options are listed above.
  * @return QueryPath
  */
-function qp($document = NULL, $string = NULL, $options = array()) {
-    return QueryPath::with($document, $string, $options);
+function qp3($document = NULL, $string = NULL, $options = array()) {
+    return \QueryPath\QueryPath::with($document, $string, $options);
 }
 
 /**
- * A special-purpose version of {@link qp()} designed specifically for HTML.
+ * A special-purpose version of {@link qp3()} designed specifically for HTML.
  *
- * XHTML (if valid) can be easily parsed by {@link qp()} with no problems. However,
+ * XHTML (if valid) can be easily parsed by {@link qp3()} with no problems. However,
  * because of the way that libxml handles HTML, there are several common steps that
  * need to be taken to reliably parse non-XML HTML documents. This function is
  * a convenience tool for configuring QueryPath to parse HTML.
@@ -168,14 +168,47 @@ function qp($document = NULL, $string = NULL, $options = array()) {
  *
  * Parser warning messages are also suppressed, so if the parser emits a warning,
  * the application will not be notified. This is equivalent to
- * calling @code@qp()@endcode.
+ * calling @code@qp3()@endcode.
  *
  * Warning: Character set conversions will only work if the Multi-Byte (mb) library
  * is installed and enabled. This is usually enabled, but not always.
  *
  * @ingroup querypath_core
- * @see qp()
+ * @see qp3()
  */
-function htmlqp($document = NULL, $selector = NULL, $options = array()) {
-    return QueryPath::withHTML($document, $selector, $options);
+function htmlqp3($document = NULL, $selector = NULL, $options = array()) {
+    return \QueryPath\QueryPath::withHTML($document, $selector, $options);
+}
+
+/*
+ * Register the old API in the global namespace for backwards compatibility
+ * except an old querypath version has been loaded already.
+ */
+if (!function_exists('qp')) {
+
+  /**
+   * Backwards compatibility wrapper for qp3().
+   *
+   * @ingroup querypath_core
+   * @see qp3()
+   */
+  function qp($document = NULL, $string = NULL, $options = array()) {
+    return qp3($document, $string, $options);
+  }
+
+  /**
+   * Backwards compatibility wrapper for htmlqp3().
+   *
+   * @ingroup querypath_core
+   * @see htmlqp3()
+   */
+  function htmlqp($document = NULL, $selector = NULL, $options = array()) {
+    return htmlqp3($document, $selector, $options);
+  }
+
+  /**
+   * Populate QueryPath class to global namespace for backwards compatibility.
+   */
+  class_alias('\\QueryPath\\QueryPath', '\\QueryPath');
+
 }


### PR DESCRIPTION
First some background information:
For the development of [HVRawConnectorPHP](https://github.com/mkalkbrenner/HVRawConnectorPHP/) I decided to use querypath 3.x.
Therefor the drupal integration module [HealthVault™ Connect](https://drupal.org/project/healthvault_connect) adds querypath3 as library to your drupal installation.
But as soon as you install another contrib module that depends on the [QueryPath](https://drupal.org/project/querypath) module which still contains querypath2, you end up with fatal errors because functions like qp() could not be redeclared.

Unfortunately it's not an option to upgrade the querypath library within the drupal QueryPath module, because (for whatever reason) modules like [Apache Solr Config Generator](https://drupal.org/project/apachesolr_confgen) don't work with querypath3.

But due to the fact that you introduced a \QueryPath namespace in querypath3, it's not a big problem to run querypath2 and 3 in parallel. But you have to avoid the redeclaration of the global functions qp() and htmlqp() and the class QueryPath must not be part of the global namespace.

So I applied these safe API changes to run querypath2 and 3 in parallel:
- renamed qp() to qp3()
- renamed htmlqp() to htmlqp3()
- renamed \QueryPath to \QueryPath\QueryPath

Now I can explicit use querypath3 in my module.

If querypath2 is not present, these changes happen on the fly for backwards compatibility, so that nobody has to change his existing code:
- declare function qp() as wrapper for qp3()
- declare function htmlqp() as wrapper for htmlqp3()
- declare \QueryPath as class alias for \QueryPath\QueryPath

To demonstrate the backwards compatibility I did not touch the tests in my patch.

What do you think about that?

From my point of view, the API change is OK, because querypath 3 is still very new and even the documentation on querypath.org has not been updated yet.

I'm open for a discussion or any other solution to run qp2 and qp3 in parallel.
