### PR TITLE
Updated Docs in regards to File Path after Pear install

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ If you installed QueryPath as a PEAR package, use it like this:
 
 ```php
 <?php
-require 'QueryPath/qp.php';
+require 'QueryPath/QueryPath.php';
 ?>
 ```
 


### PR DESCRIPTION
The docs has an incorrect file reference in regard to include after a Pear install.
