### PR TITLE
\QueryPath\QueryPath class doesn't exists.

### DIFF
--- a/src/qp.php
+++ b/src/qp.php
@@ -24,7 +24,7 @@
 
 // This is sort of a last ditch attempt to load QueryPath if no
 // autoloader is used.
-if (!class_exists('\QueryPath\QueryPath')) {
+if (!class_exists('\QueryPath')) {
 
   // If classloaders are explicitly disabled, load everything.
   if (defined('QP_NO_AUTOLOADER')) {


### PR DESCRIPTION
The class QueryPath is not contained in the QueryPath namespace so the full name of the QueryPath class is \QueryPath and not \QueryPath\QueryPath making the first `if` to be always true
