### PR TITLE
DOMQuery::text() does not work as intended

### DIFF
--- a/src/QueryPath/DOMQuery.php
+++ b/src/QueryPath/DOMQuery.php
@@ -2463,8 +2463,7 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
   public function text($text = NULL) {
     if (isset($text)) {
       $this->removeChildren();
-      $textNode = $this->document->createTextNode($text);
-      foreach ($this->matches as $m) $m->appendChild($textNode);
+      foreach ($this->matches as $m) $m->appendChild($this->document->createTextNode($text));
       return $this;
     }
     // Returns all text as one string:

--- a/test/Tests/QueryPath/DOMQueryTest.php
+++ b/test/Tests/QueryPath/DOMQueryTest.php
@@ -1331,6 +1331,7 @@ class DOMQueryTest extends TestCase {
     $xml = '<?xml version="1.0"?><root><div>Text A</div><div>Text B</div></root>';
     $this->assertEquals('Text AText B', qp($xml)->text());
     $this->assertEquals('Foo', qp($xml, 'div')->eq(0)->text('Foo')->text());
+    $this->assertEquals('BarBar', qp($xml, 'div')->text('Bar')->text());
   }
 
   public function testTextAfter() {


### PR DESCRIPTION
Hi!

I'm not sure whether this is a bug or I am doing something wrong.

When using the text() method to set text contents of all matched elements,
I get the following result:

Test script:

``` php
<?php
$xml = '<?xml version="1.0"?><root><div>Text A</div><div>Text B</div></root>';
qp($xml, 'div')->text('New Text')->writeXML();
```

Expected result:

``` xml
<?xml version="1.0"?><root><div>New Text</div><div>New Text</div></root>
```

Actual result:

``` xml
<?xml version="1.0"?><root><div /><div>New Text</div></root>
```

This Pull Request fixes this behavior and adds an unit test for it.
