### PR TITLE
Fix wrapInner()

### DIFF
--- a/src/QueryPath/DOMQuery.php
+++ b/src/QueryPath/DOMQuery.php
@@ -1645,22 +1645,25 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
     // No data? Short circuit.
     if (empty($data)) return $this;
 
-    if ($data->hasChildNodes()) {
-      $deepest = $this->deepestNode($data);
-      // FIXME: ???
-      $bottom = $deepest[0];
-    }
-    else
-      $bottom = $data;
-
     foreach ($this->matches as $m) {
+      $wrapper = $data->firstChild->cloneNode(true);
+
+      if ($wrapper->hasChildNodes()) {
+        $deepest = $this->deepestNode($wrapper);
+        // FIXME: ???
+        $bottom = $deepest[0];
+      }
+      else
+        $bottom = $wrapper;
+
       if ($m->hasChildNodes()) {
         while($m->firstChild) {
           $kid = $m->removeChild($m->firstChild);
           $bottom->appendChild($kid);
         }
       }
-      $m->appendChild($data);
+
+      $m->appendChild($wrapper);
     }
     return $this;
   }

--- a/test/Tests/QueryPath/DOMQueryTest.php
+++ b/test/Tests/QueryPath/DOMQueryTest.php
@@ -886,6 +886,10 @@ class DOMQueryTest extends TestCase {
     $xml = qp($file,'#inner-one')->wrapInner('<test class="testWrap"></test>')->get(0)->ownerDocument->saveXML();
     // FIXME: 9 includes text nodes. Should fix this.
     $this->assertEquals(9, qp($xml, '.testWrap')->get(0)->childNodes->length);
+
+    $xml = qp($file,'inner')->wrapInner('<test class="testWrap"></test>')->get(0)->ownerDocument->saveXML();
+    $this->assertEquals(9, qp($xml, '.testWrap')->get(0)->childNodes->length);
+    $this->assertEquals(3, qp($xml, '.testWrap')->get(1)->childNodes->length);
   }
 
   public function testRemove() {


### PR DESCRIPTION
Hi!!

I'd like to suggest this patch.
This PR fixes the following behavior of `wrapInner()`:

Test script:

``` php
$qp = qp('<?xml version="1.0"?><root><div>Text A</div><div>Text B</div></root>');
$qp->find('div')->wrapInner('<test/>')->writeXML();
```

Expected result:

``` xml
<?xml version="1.0"?><root><div><test>Text A</test></div><div><test>Text B</test></div></root>
```

Actual result:

``` xml
<?xml version="1.0"?><root><div><test>Text AText B</test></div><div/></root>
```
