### PR TITLE
Change in css function

### DIFF
--- a/src/QueryPath/DOMQuery.php
+++ b/src/QueryPath/DOMQuery.php
@@ -587,10 +587,14 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
       return $this->attr('style');
     }
 
-    // Get any existing CSS.
-    $css = array();
-    foreach ($this->matches as $match) {
+    
+    foreach ($this->matches as $match) { 
+       // Get any existing CSS.  //+
+       $css = array();   //The css is restored in every repetition of the loop, so that it doesn't
+	    		 //homogenize all of the matches to share ALL their css attributes, only
+	    		 //the ones indicated in the parameters.
       $style = $match->getAttribute('style');
+      //$style =$this->attr('style');
       if (!empty($style)) {
         // XXX: Is this sufficient?
         $style_array = explode(';', $style);
@@ -604,26 +608,29 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
           $css[$css_att] = trim($css_val);
         }
       }
-    }
+	  if (is_array($name)) {
+	    // Use array_merge instead of + to preserve order.
+	    $css = array_merge($css, $name);
+	  }
+	  else {
+	    $css[$name] = $value;
+	  }
 
-    if (is_array($name)) {
-      // Use array_merge instead of + to preserve order.
-      $css = array_merge($css, $name);
-    }
-    else {
-      $css[$name] = $value;
-    }
+	  // Collapse CSS into a string.
+	  $format = '%s: %s;';
+	  $css_string = '';
+	  foreach ($css as $n => $v) {
+	    $css_string .= sprintf($format, $n, trim($v));
+	  }
 
-    // Collapse CSS into a string.
-    $format = '%s: %s;';
-    $css_string = '';
-    foreach ($css as $n => $v) {
-      $css_string .= sprintf($format, $n, trim($v));
+	  //$this->attr('style', $css_string);  //Deprecated: instead of sharing the same style for all the matches,
+	                                        //            the change in the css will be applied finely for 
+	                                        //            each match without homogenization
+	  $match->setAttribute('style', $css_string);
     }
-
-    $this->attr('style', $css_string);
     return $this;
-  }
+  } //End of css function 
+
 
   /**
    * Insert or retrieve a Data URL.


### PR DESCRIPTION
Dear team of querypath: the css function needed a correction, so that it had the expected behavior when applying the css function. I compared this behaviour with JQuery and fortunately JQuery DOES behave in the expected matter, so querypath was the one behind. The error was as follows:
When making a css change, for example, we want to change a color:
 $qp($html, "p")->css("color", "blue");
but the behaviour was unbelievable: all of the "p" tags ended up with the same styles! If, for example, one <p> tag had a style of "margin-bottom: 2px", then this rule would spread in ALL of the other "<p>" tags even though we originally wanted to change only the color (!!). This was due to the way in which the loop and assignment of css style was assigned. 

Now the assignment is as it should be, and as it works in JQuery: ONLY CHANGE the specific attribute in the style of the css of each specific match element in the loop, without homogenizing the same style string for all of the matches.

Thanks, 

Best regards from Colombia, South America.

David López
http://investigacionyprogramacion.com