### PR TITLE
Fix composer.json schema

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "querypath/QueryPath",
+  "name": "querypath/querypath",
   "type": "library",
   "description": "HTML/XML querying (CSS 4 or XPath) and processing (like jQuery)",
   "homepage": "https://github.com/technosophos/querypath",
@@ -8,6 +8,9 @@
   "require" : {
     "php" : ">=5.3.0",
     "masterminds/html5": "2.*"
+  },
+  "extra": {
+    "installer-name": "QueryPath"
   },
   "autoload": {
     "psr-0": {"QueryPath": "src/"},


### PR DESCRIPTION
Fixes `$ composer validate`:
```
libraries/querypath/composer.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
See https://getcomposer.org/doc/04-schema.md for details on the schema
Name "querypath/QueryPath" does not match the best practice (e.g. lower-cased/with-dashes). We suggest using "querypath/query-path" instead. As such you will not be able to submit it to Packagist.
```