### PR TITLE
PHP 8 error handler fix about removed parameter context

### DIFF
--- a/src/QueryPath/IOException.php
+++ b/src/QueryPath/IOException.php
@@ -13,7 +13,7 @@ namespace QueryPath;
  * @ingroup querypath_core
  */
 class IOException extends \QueryPath\ParseException {
-  public static function initializeFromError($code, $str, $file, $line, $cxt) {
+  public static function initializeFromError($code, $str, $file, $line, $cxt = NULL) {
     $class = __CLASS__;
     throw new $class($str, $code, $file, $line);
   }

--- a/src/QueryPath/ParseException.php
+++ b/src/QueryPath/ParseException.php
@@ -36,7 +36,7 @@ class ParseException extends \QueryPath\Exception {
     parent::__construct($msg, $code);
   }
 
-  public static function initializeFromError($code, $str, $file, $line, $cxt) {
+  public static function initializeFromError($code, $str, $file, $line, $cxt = NULL) {
     //printf("\n\nCODE: %s %s\n\n", $code, $str);
     $class = __CLASS__;
     throw new $class($str, $code, $file, $line);


### PR DESCRIPTION
In PHP 8 the 5th parameter context was removed from the errors passed to the error handlers attached with set_error_handler. 
Therefore the two eror handler functions creating the io and parse exception are changed to respect that. 