### PR TITLE
PHP 8.1: Deprecated function: trim()

### DIFF
--- a/src/QueryPath/DOMQuery.php
+++ b/src/QueryPath/DOMQuery.php
@@ -96,8 +96,8 @@ class DOMQuery implements \QueryPath\Query, \IteratorAggregate, \Countable {
    *   An associative array of options.
    * @see qp()
    */
-  public function __construct($document = NULL, $string = NULL, $options = array()) {
-    $string = trim($string);
+  public function __construct($document = NULL, $string = '', $options = array()) {
+    $string = trim( (string)$string );
     $this->options = $options + Options::get() + $this->options;
 
     $parser_flags = isset($options['parser_flags']) ? $options['parser_flags'] : self::DEFAULT_PARSER_FLAGS;


### PR DESCRIPTION
Commit fixes:
Deprecated function: trim(): Passing null to parameter https://github.com/technosophos/querypath/issues/1 ($string) of type string is deprecated in QueryPath\DOMQuery->__construct() (line 100 of /querypath/querypath/src/QueryPath/DOMQuery.php).
Issue:
https://github.com/technosophos/querypath/issues/213