### PR TITLE
PHP8.2 compatibility: Deprecated function: Creation of dynamic property

### DIFF
--- a/src/QueryPath/CSS/Parser.php
+++ b/src/QueryPath/CSS/Parser.php
@@ -21,6 +21,7 @@ namespace QueryPath\CSS;
  *
  * @ingroup querypath_css
  */
+#[\AllowDynamicProperties]
 class Parser {
   protected $scanner = NULL;
   protected $buffer = '';


### PR DESCRIPTION
add PHP8.2 support for the "Parser" class by adding #[\AllowDynamicProperties] property https://www.php.net/manual/en/class.allowdynamicproperties.php